### PR TITLE
feat: add variable to set the hostgroup parameters

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -40,7 +40,9 @@ tags: []
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies: {
+  community.general: '>=9.3.0'
+}
 
 # The URL of the originating SCM repository
 repository: http://example.com/repository

--- a/roles/satellite/defaults/main.yml
+++ b/roles/satellite/defaults/main.yml
@@ -1,2 +1,11 @@
 ---
 satellite_verify_ssl: true
+
+satellite_hostgroup_parameters_defaults:
+  - name: "kt_activation_keys"
+    value: "{{ g_test_activationkey }}"
+  - name: "keyboard"
+    value: "us"
+  - name: "remote_execution_ssh_keys"
+    parameter_type: "array"
+    value: []

--- a/roles/satellite/tasks/internals/activationkey-hostgroup-definition.yml
+++ b/roles/satellite/tasks/internals/activationkey-hostgroup-definition.yml
@@ -34,11 +34,7 @@
     parent: "{{ hostvars[groups['test'][0]]['hostgroup_parent'] if g_test_hostgroup_parent_is_groupvar else test_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['test'][0]]['pxe_loader'] if g_test_pxe_loader_is_groupvar else test_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters:
-    - name: "kt_activation_keys"
-      value: "{{ g_test_activationkey }}"
-    - name: "keyboard"
-      value: "{{ keyboard | default('us') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
   when: g_test_lifecycleenvironment_defined and g_test_activationkey_defined and g_test_hostgroup_defined
 
@@ -78,10 +74,6 @@
     parent: "{{ hostvars[groups['prod'][0]]['hostgroup_parent'] if g_prod_hostgroup_parent_is_groupvar else prod_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['prod'][0]]['pxe_loader'] if g_prod_pxe_loader_is_groupvar else prod_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters:
-    - name: "kt_activation_keys"
-      value: "{{ g_prod_activationkey }}"
-    - name: "keyboard"
-      value: "{{ keyboard | default('us') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
   when: g_prod_lifecycleenvironment_defined and g_prod_activationkey_defined and g_prod_hostgroup_defined

--- a/roles/satellite/tasks/internals/activationkey-hostgroups-deprovision.yml
+++ b/roles/satellite/tasks/internals/activationkey-hostgroups-deprovision.yml
@@ -19,11 +19,7 @@
     parent: "{{ hostvars[groups['prod'][0]]['hostgroup_parent'] if g_prod_hostgroup_parent_is_groupvar else prod_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['prod'][0]]['pxe_loader'] if g_prod_pxe_loader_is_groupvar else prod_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters:
-    - name: "kt_activation_keys"
-      value: "{{ g_prod_activationkey }}"
-    - name: "keyboard"
-      value: "{{ keyboard | default('us') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
     state: absent
   when: g_prod_lifecycleenvironment_defined and g_prod_activationkey_defined and g_prod_activationkey_defined
@@ -67,11 +63,7 @@
     parent: "{{ hostvars[groups['test'][0]]['hostgroup_parent'] if g_test_hostgroup_parent_is_groupvar else test_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['test'][0]]['pxe_loader'] if g_test_pxe_loader_is_groupvar else test_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters:
-    - name: "kt_activation_keys"
-      value: "{{ g_test_activationkey }}"
-    - name: "keyboard"
-      value: "{{ keyboard | default('us') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
     state: absent
   when: g_test_lifecycleenvironment_defined and g_test_activationkey_defined and g_test_hostgroup_defined


### PR DESCRIPTION
This PR adds a variable to set the hostgroups parameters, instead of having to create a new Ansible variable for each one. I've created a default variable that is then merged with the `hostgroup_parameters` variable coming from the caller playbooks. If the caller overloads the same parameters, then it is their values that overload the default ones.