### PR TITLE
Allow overriding hostgroup parameters based on the inventory group

### DIFF
--- a/roles/satellite/tasks/internals/activationkey-hostgroup-definition.yml
+++ b/roles/satellite/tasks/internals/activationkey-hostgroup-definition.yml
@@ -34,7 +34,7 @@
     parent: "{{ hostvars[groups['test'][0]]['hostgroup_parent'] if g_test_hostgroup_parent_is_groupvar else test_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['test'][0]]['pxe_loader'] if g_test_pxe_loader_is_groupvar else test_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([]), test_hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
   when: g_test_lifecycleenvironment_defined and g_test_activationkey_defined and g_test_hostgroup_defined
 
@@ -74,6 +74,6 @@
     parent: "{{ hostvars[groups['prod'][0]]['hostgroup_parent'] if g_prod_hostgroup_parent_is_groupvar else prod_hostgroup_parent | default(omit) }}"
     pxe_loader: "{{ hostvars[groups['prod'][0]]['pxe_loader'] if g_prod_pxe_loader_is_groupvar else prod_pxe_loader | default(omit) }}"
     locations: "{{ locations.keys() | list }}"
-    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
+    parameters: "{{ [satellite_hostgroup_parameters_defaults, hostgroup_parameters | default([]), prod_hostgroup_parameters | default([])] | community.general.lists_mergeby('name') }}"
     content_view: "{{ deploymentcontentview }}"
   when: g_prod_lifecycleenvironment_defined and g_prod_activationkey_defined and g_prod_hostgroup_defined


### PR DESCRIPTION
Satellite hostgroups may have different values for some parameters based on the inventory grouping.

This allows to configure some features differently for production and testing lifecycle environments.