### PR TITLE
Remove default values for keyboard and remote_execution_ssh_keys

### DIFF
--- a/roles/satellite/defaults/main.yml
+++ b/roles/satellite/defaults/main.yml
@@ -1,9 +1,4 @@
 ---
 satellite_verify_ssl: true
 
-satellite_hostgroup_parameters_defaults:
-  - name: "keyboard"
-    value: "us"
-  - name: "remote_execution_ssh_keys"
-    parameter_type: "array"
-    value: []
+satellite_hostgroup_parameters_defaults: []


### PR DESCRIPTION
When setting up a default value globally in Satellite, these defaults here are overriding the global satellite settings in a specific group.